### PR TITLE
docs: remove AI-slop writing patterns

### DIFF
--- a/DESIGN_CRITIQUE.md
+++ b/DESIGN_CRITIQUE.md
@@ -96,6 +96,6 @@ These are the remaining actionable concerns, ordered by impact:
 
 ## Summary
 
-The framework has matured significantly. The handler/plugin architecture, boundary enforcement subsystem, and multi-domain bridge ecosystem represent substantial architectural progress. Of the original 7 design concerns, 3 are fully resolved (#2 dataclass/pydantic, #4 observable generator, and implicitly #3 weight semantics via documentation). Two architectural questions are answered (#1 v_hat/p separation, #2 sigmoid calibration). The remaining concerns — event coupling, metadata typing, and further Orchestrator decomposition — are real but non-blocking, and represent incremental cleanup rather than structural issues.
+The handler/plugin architecture, boundary enforcement subsystem, and multi-domain bridge ecosystem have advanced the design. Of the original 7 design concerns, 3 are fully resolved (#2 dataclass/pydantic, #4 observable generator, and implicitly #3 weight semantics via documentation). Two architectural questions are answered (#1 v_hat/p separation, #2 sigmoid calibration). The remaining concerns — event coupling, metadata typing, and further Orchestrator decomposition — are non-blocking and represent incremental cleanup rather than structural issues.
 
 The core insight — using soft probabilistic labels to measure adverse selection and quality gaps — remains sound and is now battle-tested across multiple bridge integrations.

--- a/research/posts/circuit_breakers_dominate.md
+++ b/research/posts/circuit_breakers_dominate.md
@@ -8,9 +8,9 @@
 
 ## We tested 7 governance regimes across 70 runs. One mechanism crushed the rest.
 
-We just finished the most statistically productive sweep in our kernel market series — 7 governance regimes, 10 seeds each, 70 total runs. The question: which governance lever matters most for multi-agent safety?
+We just finished the most statistically productive sweep in our kernel market series — 7 governance regimes, 10 seeds each, 70 total runs. Which governance lever matters most for multi-agent safety?
 
-**The answer: circuit breakers.** Not audits. Not staking. Not reputation. Not taxes. Not "all of the above."
+**Circuit breakers.** Audits, staking, reputation, and taxes all underperformed.
 
 The numbers:
 

--- a/research/posts/smarter_agents_earn_less.md
+++ b/research/posts/smarter_agents_earn_less.md
@@ -17,7 +17,7 @@ Honest agents (no recursion, no strategic modeling) earn 2.3-2.8x more than the 
 We tested three hypotheses:
 
 **H1: "Deep recursion enables implicit collusion."**
-Rejected. Depth-5 agents don't coordinate better than depth-1. They overthink, model counterparties who are also overthinking, and spiral into mutually suboptimal strategies.
+Rejected. Depth-5 agents don't coordinate better than depth-1. They over-model counterparties who are also overthinking, creating mutual suboptimality.
 
 **H2: "Memory asymmetry creates power imbalances."**
 Technically yes (r = +0.67, p < 0.001), but the effect is tiny — 3.2% payoff spread between the highest and lowest memory budgets. Not the dominance hierarchy you'd expect.

--- a/research/posts/wang_2024_letter.md
+++ b/research/posts/wang_2024_letter.md
@@ -6,11 +6,11 @@
 
 ---
 
-## "The Model Does The Eval" - Why This Changes Everything
+## "The Model Does The Eval"
 
-Just read Zhengdong Wang's 2024 letter and it crystallizes something we've been dancing around in multi-agent safety:
+Zhengdong Wang's 2024 letter makes explicit what we've been circling around in multi-agent safety:
 
-**The core insight:** AI progress isn't about abstract "intelligence" - it's about conquering concrete evaluations. What we can measure, we can optimize. What we can't define, remains elusive.
+**The core insight:** AI progress isn't about abstract "intelligence" — it's about optimizing measurable outcomes. What we can measure, we can optimize. What we can't define, remains elusive.
 
 This explains so much:
 - Why MMLU scores went up 18.8pp in a year (legible eval)
@@ -28,11 +28,7 @@ Wang calls this the "Hayekian problem" - some capabilities resist codification b
 3. Quality gates need to check multiple orthogonal dimensions
 4. Reflexivity matters: agents will optimize whatever we measure
 
-The uncomfortable truth: we can't perfectly verify "beneficial" any more than we can perfectly define "great literature."
-
-But we can build robust *approximations* - multiple pseudo-verifiers, diversity of metrics, adversarial probing.
-
-That's what distributional safety is about.
+We can't perfectly verify "beneficial" any more than we can perfectly define "great literature." But we can build sound approximations: multiple pseudo-verifiers, diversity of metrics, adversarial probing. That's distributional safety.
 
 ---
 


### PR DESCRIPTION
## Summary

Removed AI-slop writing patterns from research posts and design documentation:

- **Binary contrasts** (circuit_breakers_dominate.md): replaced "Not X. Not Y." pattern with direct phrasing
- **Throat-clearing openers** (wang_2024_letter.md): removed "The uncomfortable truth:" and dramatic headline subtitle
- **Dramatic fragmentation** (smarter_agents_earn_less.md): consolidated fragmented sentence structure
- **Importance puffery** (DESIGN_CRITIQUE.md): removed "has matured significantly" and "substantial architectural progress"
- **Vague language** (wang_2024_letter.md): replaced "crystallizes something we've been dancing around" with "makes explicit what we've been circling around"

## Pattern categories fixed per file

- `research/posts/circuit_breakers_dominate.md`: binary contrast, colon reveal
- `research/posts/wang_2024_letter.md`: throat-clearing openers, dramatic headline, importance puffery
- `research/posts/smarter_agents_earn_less.md`: dramatic fragmentation
- `DESIGN_CRITIQUE.md`: importance puffery, weak verb phrases

🤖 Generated with [Claude Code](https://claude.com/claude-code)